### PR TITLE
Add chatbot API

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -3,8 +3,10 @@ from fastapi import APIRouter
 from app.api.v1.auth import auth_router
 from app.api.v1.users import user_router
 from app.api.v1.calendar import calendar_router
+from app.api.v1.chatbot import chatbot_router
 
 api_router = APIRouter()
 api_router.include_router(auth_router, prefix="/auth")
 api_router.include_router(user_router, prefix="/users")
 api_router.include_router(calendar_router, prefix="/calendar")
+api_router.include_router(chatbot_router, prefix="/chatbot")

--- a/backend/app/api/v1/chatbot.py
+++ b/backend/app/api/v1/chatbot.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from app.api.deps import get_or_create_user
+from app.models.users import Users
+from app.utils.llm_client import LLMClient
+from app.constants import UserLevel
+
+
+chatbot_router = APIRouter()
+
+# Temporary system prompts per level
+SYSTEM_PROMPTS = {
+    UserLevel.BEGINNER: "당신은 주식 투자를 처음 접한 사용자를 돕는 친절한 조력자입니다.",
+    UserLevel.INTERMEDIATE: "당신은 투자 경험이 어느 정도 있는 사용자를 위한 조력자입니다.",
+    UserLevel.ADVANCED: "당신은 고급 투자 지식을 가진 사용자를 위한 전문 조력자입니다.",
+}
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+
+class ConversationRequest(BaseModel):
+    history: List[ChatMessage] = []
+    question: str
+
+
+class EventExplainRequest(BaseModel):
+    event_info: str
+
+
+class EventFollowupRequest(BaseModel):
+    history: List[ChatMessage] = []
+    question: str
+
+
+def _build_messages(level: UserLevel, history: List[ChatMessage], question: str):
+    system_prompt = SYSTEM_PROMPTS.get(level, SYSTEM_PROMPTS[UserLevel.BEGINNER])
+    messages = [{"role": "system", "content": system_prompt}]
+    messages += [msg.dict() for msg in history]
+    messages.append({"role": "user", "content": question})
+    return messages
+
+
+@chatbot_router.post("/conversation")
+async def conversation(
+    req: ConversationRequest, db_user: Users = Depends(get_or_create_user)
+):
+    messages = _build_messages(db_user.level, req.history, req.question)
+    llm = LLMClient()
+
+    async def stream():
+        async for chunk in llm.stream_chat(messages):
+            yield chunk
+
+    return StreamingResponse(stream(), media_type="text/plain")
+
+
+@chatbot_router.post("/event/explain")
+async def explain_event(
+    req: EventExplainRequest, db_user: Users = Depends(get_or_create_user)
+):
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPTS.get(db_user.level)},
+        {"role": "user", "content": req.event_info},
+    ]
+    llm = LLMClient()
+    answer = await llm.chat(messages)
+    return {"answer": answer}
+
+
+@chatbot_router.post("/event/followup")
+async def event_followup(
+    req: EventFollowupRequest, db_user: Users = Depends(get_or_create_user)
+):
+    messages = _build_messages(db_user.level, req.history, req.question)
+    llm = LLMClient()
+    answer = await llm.chat(messages)
+    return {"answer": answer}

--- a/backend/app/utils/llm_client.py
+++ b/backend/app/utils/llm_client.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import AsyncGenerator, List, Dict
+
+from app.core.config import settings
+
+from langchain_openai import ChatOpenAI
+from langchain_anthropic import ChatAnthropic
+from langchain_core.prompts import ChatPromptTemplate
+
+
+
+class LLMClient:
+    """Simple abstraction over OpenAI and Anthropic chat APIs."""
+
+    def __init__(self) -> None:
+        self.provider = settings.ACTIVE_LLM_PROVIDER.lower()
+        self.model = settings.ACTIVE_LLM_MODEL
+        if self.provider == "openai":
+            self.llm = ChatOpenAI(model=self.model, api_key=settings.OPENAI_API_KEY)
+        elif self.provider == "anthropic":
+            self.llm = ChatAnthropic(model=self.model, api_key=settings.ANTHROPIC_API_KEY)
+        else:
+            raise ValueError("Unsupported LLM provider")
+
+    async def stream_chat(self, messages: List[Dict[str, str]]) -> AsyncGenerator[str, None]:
+        """Yield assistant message chunks using LCEL."""
+        prompt = ChatPromptTemplate.from_messages([(m["role"], m["content"]) for m in messages])
+        chain = prompt | self.llm
+        async for chunk in chain.astream({}):
+            if chunk.content:
+                yield chunk.content
+
+    async def chat(self, messages: List[Dict[str, str]]) -> str:
+        """Return full assistant message."""
+        prompt = ChatPromptTemplate.from_messages([(m["role"], m["content"]) for m in messages])
+        chain = prompt | self.llm
+        result = await chain.ainvoke({})
+        return result.content if hasattr(result, "content") else str(result)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,8 @@ python-dotenv>=1.0.0
 pydantic==2.11.7
 pydantic-settings==2.9.1
 pydantic_core==2.33.2
+openai>=1.0.0
+anthropic>=0.21.0
+langchain-core
+langchain-openai
+langchain-anthropic


### PR DESCRIPTION
## Summary
- add AI chatbot API endpoints with streaming support
- implement generic LLM client for OpenAI or Anthropic
- register chatbot router
- add openai and anthropic dependencies
- use LCEL for LLM client
- remove runtime dependency guards in LLM client

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687368ab87d4832f85501c97daadc528